### PR TITLE
Automatic part processing

### DIFF
--- a/bushexa/chroniccrawler/admin.py
+++ b/bushexa/chroniccrawler/admin.py
@@ -1,13 +1,14 @@
 from django.contrib import admin
 
-from .models import LaneToTrack, UlsanBus_LaneToTrack, NodeOfLane, PosOfBus, UlsanBus_TimeTable, DayInfo, UlsanBus_NodeToTrack, UlsanBus_ArrivalInfo, LaneAlias, LanePart
+from .models import LaneToTrack, UlsanBus_LaneToTrack, NodeOfLane, PosOfBus, UlsanBus_TimeTable, DayInfo, UlsanBus_NodeToTrack, UlsanBus_ArrivalInfo, LaneAlias, LanePart, PartOfLane, MapToAlias
 
 admin.site.register(LaneToTrack)
 admin.site.register(NodeOfLane)
 admin.site.register(PosOfBus)
 
 admin.site.register(LaneAlias)
-admin.site.register(LanePart)
+admin.site.register(PartOfLane)
+admin.site.register(MapToAlias)
 
 admin.site.register(DayInfo)
 

--- a/bushexa/chroniccrawler/crawler/autopart.py
+++ b/bushexa/chroniccrawler/crawler/autopart.py
@@ -1,0 +1,89 @@
+from chroniccrawler.models import LaneToTrack, NodeOfLane, PartOfLane, UlsanBus_NodeToTrack
+
+
+def get_all_nodes_to_check():
+    nodes = NodeOfLane.objects.all()
+    return nodes
+
+
+def group_by_lane_and_node(nodes):
+    nodes = nodes.order_by('route_key', 'node_order')
+
+    lanes = LaneToTrack.objects.all()
+
+    lanes_and_nodes = {}
+    
+    for lane in lanes:
+        lanes_and_nodes[lane.route_id] = [lane, []]
+
+    for node in nodes:
+        rid = node.route_key.route_id
+        if rid in lanes_and_nodes:
+            lanes_and_nodes[rid][1].append(node)
+
+    new_lan = []
+
+    for key in lanes_and_nodes:
+        new_lan.append(lanes_and_nodes[key])
+
+    return new_lan
+
+
+def make_groups(lans):
+    track_nodes_qset = UlsanBus_NodeToTrack.objects.all()
+    track_nodes = [n.node_id for n in track_nodes_qset]
+
+    groups = []
+
+    for lan in lans:
+        lane = lan[0]
+        nodes = lan[1]
+
+        group = [lane, []]
+
+        first_node = nodes[0]
+
+        for node in nodes[:-1]:
+            if node.node_id[3:] in track_nodes: 
+                # BEWARE! HARDCODED VALUE! NODE ID PREFIX MIGHT NOT BE 3 LETTERS IN [3:]!
+                group[1].append([first_node, node])
+
+        groups.append(group)
+
+    return groups
+
+
+def make_parts(groups):
+    PartOfLane.objects.all().delete()    
+
+    for group in groups:
+        lane = group[0]
+        pairs = group[1]
+        counter = 0
+
+        for pair in pairs:
+            start = pair[0]
+            end = pair[1]
+
+            partname = lane.bus_name + "/" + str(start.node_order) + "~" + str(end.node_order)
+
+            part = PartOfLane(lane_key=lane, first_node_key=start,
+                last_node_key=end, part_name=partname, count=counter)
+
+            part.save()
+
+            counter = counter + 1
+
+    return 0
+
+
+def do_lanepart():
+    lanes = get_all_nodes_to_check()
+
+    lans = group_by_lane_and_node(lanes)
+
+    groups = make_groups(lans)
+
+    make_parts(groups)
+
+    return 0

--- a/bushexa/chroniccrawler/helper/helper.py
+++ b/bushexa/chroniccrawler/helper/helper.py
@@ -47,7 +47,7 @@ def get_arrival_list(parts):
 def format_position_list(lanes):
     # add format and position
     for lane in lanes:
-        lane['remain_stops'] = lane['part'].end_node_key.node_order - lane['pos'].node_order
+        lane['remain_stops'] = lane['part'].last_node_key.node_order - lane['pos'].node_order
         lane['thing'] = {'remain_time': str(lane['remain_stops']) + '역 전',
                          'stop_name': NodeOfLane.objects.get(route_key=lane['lane'],
                                                              node_order=lane['pos'].node_order).node_name}
@@ -138,7 +138,21 @@ def cleanup_arrivals_and_positions(arrs, poss):
 # Construct information for next n bus'
 def next_n_bus_from_alias(alias, n):
     count = n
-    parts = LanePart.objects.filter(alias_key=alias)
+
+    maps = MapToAlias.objects.filter(alias_key=alias)
+    parts = []
+    for m in maps:
+        lane = m.lane_key
+        count = m.count
+        part = None
+        try:
+            part = PartOfLane.objects.get(lane_key=lane, count=count)
+        except:
+            continue
+        else:
+            if part is not None:
+                parts.append(part)
+
     arrivals = get_arrival_list(parts)
     positions = get_position_list(parts)
     dispatches = get_dispatch_list(parts)

--- a/bushexa/chroniccrawler/management/commands/dotask.py
+++ b/bushexa/chroniccrawler/management/commands/dotask.py
@@ -6,6 +6,7 @@ from chroniccrawler.crawler.timetable_usb import do_timetable
 from chroniccrawler.crawler.buspos import do_buspos
 from chroniccrawler.crawler.arrivalinfo import do_arrivalinfo
 from chroniccrawler.crawler.timed import do_timed
+from chroniccrawler.crawler.autopart import do_lanepart
 
 from chroniccrawler.models import DayInfo
 
@@ -20,6 +21,7 @@ class Command(BaseCommand):
         parser.add_argument('--date', action='store_true', help='test : do date related tasks')
         parser.add_argument('--lane', action='store_true', help='test : do lane related tasks')
         parser.add_argument('--timetable', action='store_true', help='test : do timetable related tasks')
+        parser.add_argument('--autopart', action='store_true', help='test : do autopart of lanes')
 
     def handle(self, *args, **options):
         if options['daily']:
@@ -27,6 +29,7 @@ class Command(BaseCommand):
             do_laneinfo()
             dayinfo = DayInfo.objects.first()
             do_timetable(dayinfo.kind)
+            do_lanepart()
         elif options['timed']:
             do_timed()
         elif options['date']:
@@ -40,3 +43,5 @@ class Command(BaseCommand):
             do_buspos()
         elif options['arrival']:
             do_arrivalinfo()
+        elif options['autopart']:
+            do_lanepart()

--- a/bushexa/chroniccrawler/models.py
+++ b/bushexa/chroniccrawler/models.py
@@ -146,3 +146,40 @@ class LanePart(models.Model):
                 and self.end_node_key.node_order > buspos.node_order:
                 return True
         return False
+
+
+# New part / alias system from here
+
+class PartOfLane(models.Model):
+    lane_key = models.ForeignKey(LaneToTrack, on_delete=models.CASCADE)
+    first_node_key = models.ForeignKey(NodeOfLane, on_delete=models.CASCADE, related_name="fnk")
+    last_node_key = models.ForeignKey(NodeOfLane, on_delete=models.CASCADE, related_name="lnk")
+    part_name = models.CharField(max_length=60)
+    count = models.IntegerField()
+
+    def __str__(self):
+        return self.part_name
+
+    def only_departure(self):
+        if self.first_node_key == self.last_node_key and self.first_node_key.node_order == 1:
+            return True
+        else:
+            return False
+
+    def in_part(self, buspos):
+        if buspos.route_key == self.lane_key:
+            if self.first_node_key.node_order <= buspos.node_order \
+                and self.last_node_key.node_order > buspos.node_order:
+                return True
+        return False
+
+
+class MapToAlias(models.Model):
+    lane_key = models.ForeignKey(LaneToTrack, on_delete=models.CASCADE)
+    count = models.IntegerField()
+    alias_key = models.ForeignKey(LaneAlias, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return "Map count " + str(self.count) + " of " + self.lane_key.route_id + " to " + self.alias_key.alias_name
+
+


### PR DESCRIPTION
노선번호와 정류장번호에 따라 자동으로 "노선 시작 ~ 해당 정류장"까지의 PartOfLane을 생성하며
한 노선 안에서 처음 등장하는 정류장까지의 PartOfLane의 count를 0으로,
그리고 그 이후 생성되는 동일 노선의 PartOfLane의 경우 count가 1씩 증가합니다.

MapToAlias를 통해 "정류장번호"의 ("count" + 1)번째 PartOfLane을 Alias에 연결시킬 수 있습니다.

LanePart는 버립니다