### PR TITLE
Fix : Departure performance issue

### DIFF
--- a/bushexa/chroniccrawler/helper/helper.py
+++ b/bushexa/chroniccrawler/helper/helper.py
@@ -1,6 +1,9 @@
 import sys
 import datetime
 import copy
+
+from django.db.models import Exists, OuterRef
+
 from chroniccrawler.models import *
 
 
@@ -92,34 +95,26 @@ def format_dispatch_list(things):
 
 # 3rd : get dispatch part
 def get_dispatch_list(parts):
-    # add lane
-    lanes = [{'part':p, 'lane':p.lane_key} for p in parts]
-    # add usblane
-    usblanes = UlsanBus_LaneToTrack.objects.filter(route_key__in=[l['lane'] for l in lanes])
-    for lane in lanes:
-        for usbl in usblanes:
-            if lane['lane'] == usbl.route_key:
-                lane['usblane'] = usbl
-    # for each lane
+    route_keys = parts.values_list('lane_key')
+    route_key_usbs = UlsanBus_LaneToTrack.objects.filter(route_key__in=route_keys)
+    timetables = UlsanBus_TimeTable.objects.filter(route_key_usb__in=route_key_usbs)
     things = []
     now = datetime.datetime.now()
     nowformat = now.hour * 100 + now.minute
-    for lane in lanes:
-        # get timetables
-        dps = UlsanBus_TimeTable.objects.filter(route_key_usb=lane['usblane'])
-        # filter timetable earilier than now
-        ndps = []
-        for dp in dps:
-            if int(dp.depart_time) >= nowformat:
-                ndps.append(dp)
-        for dp in ndps:
-            thing = copy.deepcopy(lane)
-            thing['dispatch'] = dp
-            things.append(thing)
-    # format
-    things = sorted(things, key=lambda d: int(d['dispatch'].depart_time))
-    return format_dispatch_list(things)
-        
+    for tt in timetables:
+        if int(tt.depart_time) >= nowformat:
+            things.append(  {
+                                'remain_stops': sys.maxsize,
+                                'dptime': int(tt.depart_time),
+                                'thing':
+                                    {
+                                        'bus_time':tt.depart_time[0:2]+':'+tt.depart_time[2:4],
+                                    },
+                            })
+    things = sorted(things, key=lambda d: d['dptime'])
+
+    return things
+
 # Cleanup duplicates inside functions
 def cleanup_arrivals_and_positions(arrs, poss):
     # Find duplicate entries that are in both arrivals and positions and delete from positions
@@ -141,21 +136,21 @@ def cleanup_arrivals_and_positions(arrs, poss):
 def next_n_bus_from_alias(alias, n):
     count = n
 
-    maps = MapToAlias.objects.filter(alias_key=alias)
-    parts = []
+    #maps = MapToAlias.objects.filter(alias_key=alias).values_list('lane_key', 'count')
+
+     
+    parts = PartOfLane.objects.filter(
+                    Exists(
+                            MapToAlias.objects.filter(
+                                    lane_key_id=OuterRef('lane_key_id'), count=OuterRef('count'), alias_key=alias
+                            )
+                    )
+            ).select_related('lane_key')
+    
     only_departure = True
-    for m in maps:
-        lane = m.lane_key
-        count = m.count
-        part = None
-        try:
-            part = PartOfLane.objects.get(lane_key=lane, count=count)
-        except:
-            continue
-        else:
-            only_departure = only_departure and part.only_departure()
-            if part is not None:
-                parts.append(part)
+    for p in parts:
+        now_only_departure = p.first_node_key == p.last_node_key and p.first_node_key.node_order == 1
+        only_departure = only_departure and now_only_departure
 
     arrivals = get_arrival_list(parts)
     positions = get_position_list(parts)

--- a/bushexa/chroniccrawler/helper/helper.py
+++ b/bushexa/chroniccrawler/helper/helper.py
@@ -138,7 +138,7 @@ def next_n_bus_from_alias(alias, n):
                                     lane_key_id=OuterRef('lane_key_id'), count=OuterRef('count'), alias_key=alias
                             )
                     )
-            ).select_related('lane_key')
+            ).select_related('lane_key', 'first_node_key', 'last_node_key')
     
     only_departure = True
     for p in parts:

--- a/bushexa/chroniccrawler/helper/helper.py
+++ b/bushexa/chroniccrawler/helper/helper.py
@@ -85,14 +85,6 @@ def get_position_list(parts):
     return format_position_list(nlanes)
 
 
-# format 3rd
-def format_dispatch_list(things):
-    # add format and info
-    for thing in things:
-        thing['remain_stops'] = sys.maxsize
-        thing['thing'] = {'bus_time': thing['dispatch'].depart_time[0:2]+':'+thing['dispatch'].depart_time[2:4]}
-    return things
-
 # 3rd : get dispatch part
 def get_dispatch_list(parts):
     route_keys = parts.values_list('lane_key')
@@ -114,6 +106,7 @@ def get_dispatch_list(parts):
     things = sorted(things, key=lambda d: d['dptime'])
 
     return things
+
 
 # Cleanup duplicates inside functions
 def cleanup_arrivals_and_positions(arrs, poss):

--- a/bushexa/chroniccrawler/models.py
+++ b/bushexa/chroniccrawler/models.py
@@ -65,7 +65,7 @@ class UlsanBus_TimeTable(models.Model):
     depart_seq = models.IntegerField()
 
     def __str__(self):
-        return self.route_key_usb.route_key.bus_name + " number " + str(self.depart_seq) + " departing on " + self.depart_time
+        return "Number " + str(self.depart_seq) + " departing on " + self.depart_time
 
 # Data from 울산광역시 BIS
 class UlsanBus_NodeToTrack(models.Model):
@@ -157,8 +157,11 @@ class LandmarkOfLane(models.Model):
     def __str__(self):
         return self.route_key.route_id + " passes " + str(self.landmark_keys.count()) + " landmark(s)."
 
+    # For performance, do not use this function from here
+    # Implement it in place using querysets pre-loaded with 
+    # select_related() and prefetch_related() function
     def get_passing_landmarks(self):
-        landmark_aliass = set(lmk.alias_key.alias_name for lmk in self.landmark_keys.all())
+        landmark_aliass = set(lmk.alias_key.alias_name for lmk in self.landmark_keys.all().select_related('alias_key'))
         return ", ".join(landmark_aliass)
             
 

--- a/bushexa/timetable/tools/helpers.py
+++ b/bushexa/timetable/tools/helpers.py
@@ -11,18 +11,19 @@ from .tools import *
 시간 순으로 버스 목록 표출
 """
 def get_bustime(request_time):
-    timetables = UlsanBus_TimeTable.objects.all()
+    timetables = UlsanBus_TimeTable.objects.all().select_related("route_key_usb__route_key")
+
+    lmols = LandmarkOfLane.objects.all().prefetch_related("landmark_keys").select_related("landmark_keys__alias_key")
 
     bus_time = []
-
-    now = datetime.now()
 
     for tt in timetables:
         hour = int(tt.depart_time[:2])
         minute = int(tt.depart_time[2:])
         route_key = tt.route_key_usb.route_key
         try:
-            bus_via = LandmarkOfLane.objects.get(route_key=route_key).get_passing_landmarks()
+            lmks = lmols.get(route_key=route_key).landmark_keys.all()
+            bus_via = ", ".join(set(lmk.alias_key.alias_name for lmk in lmks))
         except:
             bus_via = "Placeholder"
         #if hour > now.hour or (hour == now.hour and minute >= now.minute):


### PR DESCRIPTION
기존 로딩시간 본인 로컬 테스트 서버 기준 약 650ms

select_related()와 prefetch_related()를 활용해 n+1문제 방지

로딩시간 350ms로 감소

동일한 route_key에 대해 "노선 경유" text를 route_key_to_text dictionary에 등록해 

매 줄마다 text를 build하는것 방지

로딩시간 100ms로 감소

굿