### PR TITLE
Vacation registering & detection

### DIFF
--- a/bushexa/chroniccrawler/admin.py
+++ b/bushexa/chroniccrawler/admin.py
@@ -11,6 +11,7 @@ admin.site.register(PartOfLane)
 admin.site.register(MapToAlias)
 
 admin.site.register(DayInfo)
+admin.site.register(VacationDate)
 
 admin.site.register(UlsanBus_LaneToTrack)
 admin.site.register(UlsanBus_TimeTable)

--- a/bushexa/chroniccrawler/crawler/dayinfo.py
+++ b/bushexa/chroniccrawler/crawler/dayinfo.py
@@ -3,7 +3,7 @@ import datetime
 from .tools.getkey import get_key
 from .tools.requestor import request_dict
 
-from chroniccrawler.models import DayInfo
+from chroniccrawler.models import DayInfo, VacationDate
 
 
 def get_time():
@@ -57,6 +57,12 @@ def store_dayinfo(now, resdict):
         if oneday['locdate'] == year + month + day and oneday['isHoliday'] == 'Y':
             name = oneday['dateName']
             kind = 2
+    vacation = False
+    for vacations in VacationDate.objects.all():
+        vacation = vacation | vacations.during_vacation(now.date())
+
+    if vacation:
+        kind = kind + 3
 
     today = DayInfo(year=year, month=month, day=day, name=name, kind=kind)
     today.save()

--- a/bushexa/chroniccrawler/models.py
+++ b/bushexa/chroniccrawler/models.py
@@ -165,3 +165,18 @@ class LandmarkOfLane(models.Model):
         return ", ".join(landmark_aliass)
             
 
+# Store vacation durations
+class VacationDate(models.Model):
+    vacation_first_day = models.DateField(null=False, blank=False)
+    vacation_last_day = models.DateField(null=False, blank=False)
+    desc = models.CharField(max_length=30, blank=True)
+
+    def __str__(self):
+        return self.desc + " from " + self.vacation_first_day.strftime('%y-%m-%d') + \
+                " to " + self.vacation_last_day.strftime('%y-%m-%d')
+
+    def during_vacation(self, date):
+        if self.vacation_first_day <= date and date <= self.vacation_last_day:
+            return True
+        else:
+            return False

--- a/bushexa/chroniccrawler/readme_cc.md
+++ b/bushexa/chroniccrawler/readme_cc.md
@@ -106,6 +106,18 @@ Alias key: "어느 Lane alias에 매핑할 것인지"
 
 그 후, Landmark aliass에는 버스가 지나는 역 중 중요하며 경유역으로 표시하고 싶은 위치의 이름을 입력하고, Landmark nodes에 각 위치에 해당하는 역의 id를 모두 입력하세요.
 
+### 방학 기간 
+
+CHRONICCRAWLER 란의 Vacation dates에 직접 정보를 등록해야합니다.
+
+vacation first day : 시작일
+
+vacation last day : 마지막날
+
+desc : 설명
+
+등록 이후부터는 오늘의 날짜가 시작일-마지막날 사이에 있는 경우 일반 시간표 대신 방학 시간표를 가져옵니다.
+
 이후 밑에서 설명하는 작업 실행하기를 시행하면 나머지 DB는 알아서 채워집니다.
 
 ### 기능 : 매일 해야 할 작업 실행하기


### PR DESCRIPTION
New model : VacationDate

방학이 시작되는 날, 방학의 마지막 날, 그리고 설명을 저장합니다.

이제 dayinfo가 VacationDate의 모델들을 불러와 한 가지라도 해당하는 경우가 있다면 일반 시간표 대신 방학 시간표를 불러옵니다.

VacationDate를 직접 등록해주세요!