### PR TITLE
Reduce indlane node width

### DIFF
--- a/bushexa/static/src/css/lane.css
+++ b/bushexa/static/src/css/lane.css
@@ -1,7 +1,3 @@
-td.tt {
-    display: none;
-}
-
 .nord {
     padding-right: 0.1rem;
 }

--- a/bushexa/static/src/css/lane.css
+++ b/bushexa/static/src/css/lane.css
@@ -1,0 +1,11 @@
+td.tt {
+    display: none;
+}
+
+.nord {
+    padding-right: 0.1rem;
+}
+
+.nnm {
+    padding-left: 0.1rem;
+}

--- a/bushexa/timetable/templates/timetable/lane.html
+++ b/bushexa/timetable/templates/timetable/lane.html
@@ -3,6 +3,7 @@
 {% load static %}
 
 {% block head %}
+<link rel="stylesheet" href="/static/src/css/lane.css">
 <script>
 function ttshowhide() {
     var tts = document.getElementsByClassName("tt");
@@ -41,7 +42,7 @@ function ttshowhide() {
         </thead>
         {% for tt in timetables %}
             <tr>
-                <td class="tt" style="display: none;">{{ tt.hour }}:{{ tt.minute }}</td>
+                <td class="tt">{{ tt.hour }}:{{ tt.minute }}</td>
             </tr>
         {% endfor %}
     </table>
@@ -50,15 +51,15 @@ function ttshowhide() {
     <table>
         <thead>
             <tr>
-                <th>순번</th>
-                <th>노선</th>
+                <th class="nord">순번</th>
+                <th class="nnm">노선</th>
                 <th>운행중</th>
             </tr>
         </thead>
         {% for node in nodes %}
         <tr>
-            <td>{{ node.node_order }}</td>
-            <td>{{ node.node_name }}</td>
+            <td class="nord"><small>{{ node.node_order }}</small></td>
+            <td class="nnm">{{ node.node_name }}</td>
             <td>
                 {% if positions|reportkey:node.node_order %}
                     {{ positions|reportkey:node.node_order }}

--- a/bushexa/timetable/templates/timetable/lane.html
+++ b/bushexa/timetable/templates/timetable/lane.html
@@ -42,7 +42,7 @@ function ttshowhide() {
         </thead>
         {% for tt in timetables %}
             <tr>
-                <td class="tt">{{ tt.hour }}:{{ tt.minute }}</td>
+                <td class="tt" style="display:none">{{ tt.hour }}:{{ tt.minute }}</td>
             </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
개별 노선 표시 페이지에서

1. 정류장 순서 숫자 small로 변경
2. 정류장 순서와 이름 간 padding 감소
3. css 분리

=>

표 너비 감소 및 가독성 증가(?)