### PR TITLE
통계 수집하기

### DIFF
--- a/bushexa/analytics/admin.py
+++ b/bushexa/analytics/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/bushexa/analytics/admin.py
+++ b/bushexa/analytics/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import *
+
+admin.site.register(HourlyLoad)

--- a/bushexa/analytics/apps.py
+++ b/bushexa/analytics/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AnalyticsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'analytics'

--- a/bushexa/analytics/decorators.py
+++ b/bushexa/analytics/decorators.py
@@ -1,0 +1,19 @@
+import datetime
+from django.db.models import F
+
+from analytics.models import *
+
+
+def track_hourly_load(func):
+    def wrap(request, *args, **kwargs):
+        now = datetime.datetime.now()
+        path = request.path
+        obj, created = HourlyLoad.objects.get_or_create(
+            date=now.date(), hour=now.hour, path=path, defaults={'load': 0},
+        )
+
+        obj.load = F('load') + 1
+        obj.save()
+
+        return func(request, *args, **kwargs)
+    return wrap

--- a/bushexa/analytics/models.py
+++ b/bushexa/analytics/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/bushexa/analytics/models.py
+++ b/bushexa/analytics/models.py
@@ -1,3 +1,11 @@
 from django.db import models
 
-# Create your models here.
+class HourlyLoad(models.Model):
+    date = models.DateField()
+    hour = models.IntegerField()
+    load = models.IntegerField()
+    path = models.CharField(max_length=64)
+
+    def __str__(self):
+        return self.date.strftime('%Y-%m-%d')+', '+str(self.hour)+', '+self.path+' : '+str(self.load)+' times'
+

--- a/bushexa/analytics/tests.py
+++ b/bushexa/analytics/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/bushexa/analytics/views.py
+++ b/bushexa/analytics/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/bushexa/config/settings.py
+++ b/bushexa/config/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'analytics.apps.AnalyticsConfig',
     'timetable.apps.TimetableConfig',
     'chroniccrawler.apps.ChroniccrawlerConfig',
 ]

--- a/bushexa/timetable/views.py
+++ b/bushexa/timetable/views.py
@@ -3,10 +3,12 @@ from django.shortcuts import redirect
 # from django.http import HttpResponse, JsonResponse
 from django.views.generic import TemplateView, DetailView, ListView
 from django.views.generic.base import TemplateResponseMixin
+from django.utils.decorators import method_decorator
 from .tools.tools import *
 from .tools.helpers import *
 
 from chroniccrawler import *
+from analytics.decorators import track_hourly_load
 
 
 class TimeTableMixin:
@@ -21,6 +23,8 @@ class TimeTableMixin:
             'time_table': bus_time,
         }
 
+
+@method_decorator(track_hourly_load, name='dispatch')
 class TimeBasedBusListView(TemplateView, TimeTableMixin):
 
     template_name = "timetable/departure.html"
@@ -46,6 +50,8 @@ class BusInfoMixin:
             'bus_info': bus_info
         }
 
+
+@method_decorator(track_hourly_load, name='dispatch')
 class BusNumberBasedBusListView(TemplateView, BusInfoMixin):
 
     template_name = "timetable/busno.html"
@@ -56,6 +62,7 @@ class BusNumberBasedBusListView(TemplateView, BusInfoMixin):
         return context
 
 
+@method_decorator(track_hourly_load, name='dispatch')
 class AliasToIndividualBusView(DetailView, TemplateResponseMixin):
 
     model = LaneAlias
@@ -78,6 +85,7 @@ class AliasToIndividualBusView(DetailView, TemplateResponseMixin):
             return super().render_to_response(context, **response_kwargs)
 
 
+@method_decorator(track_hourly_load, name='dispatch')
 class AllLanesView(TemplateView):
     
     template_name = "timetable/lanes.html"
@@ -96,6 +104,7 @@ class AllLanesView(TemplateView):
         return context
         
 
+@method_decorator(track_hourly_load, name='dispatch')
 class IndividualLaneView(DetailView, TemplateResponseMixin):
 
     model = LaneToTrack


### PR DESCRIPTION
New app : analytics

New model : HourlyLoad

New decorator "analytics.decorators" : track_hourly_load

마이그레이션만 하면 그 이후로부터 매 시간마다 각 페이지가 몇번씩 요청되었는지 (정확히는 각 view의 dispatch가 몇 번 작동했는지)에 대한 통계를 수집합니다.

누가 왔는지라던가 그런거는 수집 안하고 혼자서 100번 새로고침하면 100개로 기록되는건 함정...인가? 생각해보면 그것도 통계가 맞는데