### PR TITLE
Change 순번 to 0

### DIFF
--- a/bushexa/timetable/templates/timetable/lane.html
+++ b/bushexa/timetable/templates/timetable/lane.html
@@ -51,7 +51,7 @@ function ttshowhide() {
     <table>
         <thead>
             <tr>
-                <th class="nord">순번</th>
+                <th class="nord">0</th>
                 <th class="nnm">노선</th>
                 <th>운행중</th>
             </tr>


### PR DESCRIPTION
"순번" 을 "0"으로 고쳐 추가로 너비를 줄임

이 패치부터 본인 갤럭시 S20+, 모바일 엣지/크롬에서 너비가 제일 긴 337순환 노선 좌우 스크롤 안뜸

(편의성 개선)