### PR TITLE
Crawling 재작성 및 Logging 적용

### DIFF
--- a/bushexa/chroniccrawler/crawler/daily.py
+++ b/bushexa/chroniccrawler/crawler/daily.py
@@ -1,0 +1,56 @@
+import asyncio
+import xmltodict
+
+import chroniccrawler.crawler.laneinfo as laneinfo
+import chroniccrawler.crawler.timetable_usb as timetable
+
+import chroniccrawler.crawler.tools.requestor as rq
+import chroniccrawler.crawler.tools.listifier as ls
+
+from chroniccrawler.models import DayInfo
+
+
+async def get_gather(l_u_ps, ul_u_ps):
+    loop = asyncio.get_event_loop()
+    l_task = loop.create_task(rq.get_all(l_u_ps))
+    ul_task = loop.create_task(rq.get_all(ul_u_ps))
+
+    l_texts = await l_task
+    ul_texts = await ul_task
+
+    return l_texts, ul_texts
+
+
+def do_daily():
+    lanes = laneinfo.get_all_lanes_to_request()
+    usblanes = timetable.get_all_lanes_to_request()
+
+    todayinfo = DayInfo.objects.first()
+
+    l_u_ps = laneinfo.ready_request(lanes)
+    ul_u_ps = timetable.ready_request(usblanes, todayinfo.kind)
+
+    loop = asyncio.get_event_loop()
+    l_texts, ul_texts = loop.run_until_complete(get_gather(l_u_ps, ul_u_ps))
+
+    lane_rdicts = []
+    ul_rdicts = []
+
+    for lt in l_texts:
+        if lt[1] is not None:
+            d = xmltodict.parse(lt[1])
+            lane_rdicts.append((lt[0], d))
+    for lt in ul_texts:
+        if lt[1] is not None:
+            d = xmltodict.parse(lt[1])
+            ul_rdicts.append((lt[0], d))
+
+    for lr in lane_rdicts:
+        info = ls.element_list(['response', 'body', 'totalCount'], lr[1],
+                            ['response', 'body', 'items', 'item'])
+        laneinfo.store_lane_info(lr[0], info)
+    for lr in ul_rdicts:
+        info = ls.element_list(['tableInfo', 'totalCnt'], lr[1], ['tableInfo', 'list', 'row'])
+        timetable.store_time_table(lr[0], info)
+
+    return

--- a/bushexa/chroniccrawler/crawler/daily.py
+++ b/bushexa/chroniccrawler/crawler/daily.py
@@ -12,8 +12,8 @@ from chroniccrawler.models import DayInfo
 
 async def get_gather(l_u_ps, ul_u_ps):
     loop = asyncio.get_event_loop()
-    l_task = loop.create_task(rq.get_all(l_u_ps))
-    ul_task = loop.create_task(rq.get_all(ul_u_ps))
+    l_task = loop.create_task(rq.get_all(l_u_ps, timeout=100))
+    ul_task = loop.create_task(rq.get_all(ul_u_ps, timeout=100))
 
     l_texts = await l_task
     ul_texts = await ul_task

--- a/bushexa/chroniccrawler/crawler/timed.py
+++ b/bushexa/chroniccrawler/crawler/timed.py
@@ -7,15 +7,17 @@ import chroniccrawler.crawler.arrivalinfo as arrival
 import chroniccrawler.crawler.tools.requestor as rq
 import chroniccrawler.crawler.tools.listifier as ls
 
-async def getreallyall(l_u_ps, n_u_ps):
+
+async def get_gather(l_u_ps, n_u_ps):
     loop = asyncio.get_event_loop()
-    l_tasks = [loop.create_task(rq.getit(l_u_p)) for l_u_p in l_u_ps]
-    n_tasks = [loop.create_task(rq.getit(n_u_p)) for n_u_p in n_u_ps]
+    l_task = loop.create_task(rq.get_all(l_u_ps))
+    n_task = loop.create_task(rq.get_all(n_u_ps))
 
-    l_resps = await asyncio.gather(*l_tasks)
-    n_resps = await asyncio.gather(*n_tasks)
+    l_texts = await l_task
+    n_texts = await n_task
 
-    return l_resps, n_resps
+    return l_texts, n_texts
+
 
 def do_timed():
     lanes = buspos.get_all_lanes_to_request()
@@ -25,17 +27,19 @@ def do_timed():
     n_u_ps = arrival.ready_request(nodes)
 
     loop = asyncio.get_event_loop()
-    l_resps, n_resps = loop.run_until_complete(getreallyall(l_u_ps, n_u_ps))
+    l_texts, n_texts = loop.run_until_complete(get_gather(l_u_ps, n_u_ps))
 
     l_rdicts = []
     n_rdicts = []
 
-    for l_r in l_resps:
-        d = xmltodict.parse(l_r[1])
-        l_rdicts.append((l_r[0], d))
-    for n_r in n_resps:
-        d = xmltodict.parse(n_r[1])
-        n_rdicts.append((n_r[0], d))
+    for l_r in l_texts:
+        if l_r[1] is not None:
+            d = xmltodict.parse(l_r[1])
+            l_rdicts.append((l_r[0], d))
+    for n_r in n_texts:
+        if n_r[1] is not None:
+            d = xmltodict.parse(n_r[1])
+            n_rdicts.append((n_r[0], d))
 
     for lr in l_rdicts:
         info = ls.element_list(['response', 'body', 'totalCount'], lr[1],

--- a/bushexa/chroniccrawler/crawler/tools/requestor.py
+++ b/bushexa/chroniccrawler/crawler/tools/requestor.py
@@ -16,12 +16,14 @@ async def get_one(t_u_p):
             text = await response.text()
             stat = response.status
         if stat == 200:
-            logger.debug("Succeeded response from " + str(response.real_url))
+            logger.debug("Succeeded response from " 
+                    + str(response.real_url).split('/')[2] + "/.../" 
+                    + str(response.real_url).split('/')[-1].split('?')[0])
             return (t_u_p[0], text)
         else:
             return (t_u_p, None)
     except asyncio.CancelledError:
-        logger.info("Cancelled " + str(t_u_p))
+        logger.warning("Cancelled " + str(t_u_p[0]))
         return (t_u_p, None)
 
 # Manager Async function : get t_u_p iterable as input, return thing_response pair list as output

--- a/bushexa/chroniccrawler/crawler/tools/requestor.py
+++ b/bushexa/chroniccrawler/crawler/tools/requestor.py
@@ -1,49 +1,49 @@
-import requests
-import xmltodict
 import asyncio
 import aiohttp
+import xmltodict
+import requests
 
 
-# Async task for getting response from thing_url_params and session
-async def getit(t_u_p):
-    async with aiohttp.request('GET', t_u_p[1], params=t_u_p[2]) as response:
-        text = await response.text()
-    if response.status != 200:
-        raise Exception("Status not ok...")
-    return (t_u_p[0], text)
+# One request async function : get t_u_p as input, return thing_response pair as output
+# If failed, return (t_u_p, None)
+async def get_one(t_u_p):
+    try:
+        async with aiohttp.request('GET', t_u_p[1], params=t_u_p[2]) as response:
+            text = await response.text()
+            stat = response.status
+        if stat == 200:
+            return (t_u_p[0], text)
+        else:
+            return (t_u_p, None)
+    except asyncio.CancelledError:
+        return (t_u_p, None)
 
-# Get all
-async def getall(t_u_ps):
+# Manager Async function : get t_u_p iterable as input, return thing_response pair list as output
+# Wait for 'timeout' seconds and then cancel remaining tasks
+async def get_all(t_u_ps, timeout = 9):
     loop = asyncio.get_event_loop()
-    tasks = [loop.create_task(getit(t_u_p)) for t_u_p in t_u_ps]
-    thing_responses = await asyncio.gather(*tasks)
 
-    return thing_responses
+    timer = loop.create_task(asyncio.sleep(timeout))
+    tasks = [loop.create_task(get_one(t_u_p)) for t_u_p in t_u_ps]
+    task_timer_pair = [asyncio.gather(*tasks), timer]
 
-# Returns the response converted into a dictionary
-def request_dicts(t_u_ps):
+    await asyncio.wait(task_timer_pair, return_when=asyncio.FIRST_COMPLETED)
+
+    timer.cancel()
+    for t in tasks:
+        t.cancel()
+
+    return await asyncio.gather(*tasks)
+
+
+# Get thing_url_parameter iterable as input, return thing_dictionary pair list as output
+# timeout after 'timeout' seconds, retry 'retry' times
+def request_dicts(t_u_ps, timeout = 8, retry = 0):
     loop = asyncio.get_event_loop()
-    thing_texts = loop.run_until_complete(getall(t_u_ps))
 
-    thing_rdicts = []
+    thing_texts = loop.run_until_complete(get_all(t_u_ps, timeout))
 
-    for t_r in thing_texts:
-        d = xmltodict.parse(t_r[1])
-        thing_rdicts.append((t_r[0], d))
+    loop.close()
 
-    return thing_rdicts
+    return [(t_t[0], xmltodict.parse(t_t[1])) for t_t in thing_texts if t_t[1] is not None]
 
-
-# OLD:Returns the response converted into a dictionary
-# Old school synchronous function
-def request_dict(url, params):
-    r = requests.get(url, params=params)
-    
-    if r.status_code != 200:
-        raise Exception("Abnormal response : " + str(r.status_code))
-
-    # print(r.status_code)
-    # print(r.text)
-
-    d = xmltodict.parse(r.text)
-    return d

--- a/bushexa/chroniccrawler/management/commands/dotask.py
+++ b/bushexa/chroniccrawler/management/commands/dotask.py
@@ -5,6 +5,7 @@ from chroniccrawler.crawler.laneinfo import do_laneinfo
 from chroniccrawler.crawler.timetable_usb import do_timetable
 from chroniccrawler.crawler.buspos import do_buspos
 from chroniccrawler.crawler.arrivalinfo import do_arrivalinfo
+from chroniccrawler.crawler.daily import do_daily
 from chroniccrawler.crawler.timed import do_timed
 from chroniccrawler.crawler.autopart import do_lanepart
 from chroniccrawler.crawler.landmark import do_landmark
@@ -28,9 +29,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options['daily']:
             do_dayinfo()
-            do_laneinfo()
-            dayinfo = DayInfo.objects.first()
-            do_timetable(dayinfo.kind)
+            do_daily()
             do_lanepart()
             do_landmark()
         elif options['timed']:

--- a/bushexa/chroniccrawler/management/commands/dotask.py
+++ b/bushexa/chroniccrawler/management/commands/dotask.py
@@ -15,7 +15,7 @@ from chroniccrawler.crawler.landmark import do_landmark
 from chroniccrawler.models import DayInfo
 
 
-logger = logging.getLogger('test')
+logger = logging.getLogger('bushexa')
 
 class Command(BaseCommand):
     help = "Execute request-and-store-on-database tasks.\nPlease pass only one argument per execution."
@@ -42,9 +42,11 @@ class Command(BaseCommand):
             logger.info("Lane part created")
             do_landmark()
             logger.info("Landmark checked")
-            logger.info("Daily task end")
+            logger.info("Daily task done")
         elif options['timed']:
+            logger.info("Timed task start")
             do_timed()
+            logger.info("Timed task done")
         elif options['date']:
             do_dayinfo()
         elif options['lane']:

--- a/bushexa/chroniccrawler/management/commands/dotask.py
+++ b/bushexa/chroniccrawler/management/commands/dotask.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.management.base import BaseCommand, CommandError
 
 from chroniccrawler.crawler.dayinfo import do_dayinfo
@@ -11,6 +13,9 @@ from chroniccrawler.crawler.autopart import do_lanepart
 from chroniccrawler.crawler.landmark import do_landmark
 
 from chroniccrawler.models import DayInfo
+
+
+logger = logging.getLogger('test')
 
 class Command(BaseCommand):
     help = "Execute request-and-store-on-database tasks.\nPlease pass only one argument per execution."
@@ -28,10 +33,16 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if options['daily']:
+            logger.info("Daily task start")
             do_dayinfo()
+            logger.info("Day info saved")
             do_daily()
+            logger.info("Node of lanes and timetable saved")
             do_lanepart()
+            logger.info("Lane part created")
             do_landmark()
+            logger.info("Landmark checked")
+            logger.info("Daily task end")
         elif options['timed']:
             do_timed()
         elif options['date']:

--- a/bushexa/config/settings.py
+++ b/bushexa/config/settings.py
@@ -157,6 +157,8 @@ STATICFILES_DIRS = [
 
 # Logger
 
+logger_name = 'bushexa'
+
 info_to_file = 'info_to_file'
 debug_to_file = 'debug_to_file'
 
@@ -190,7 +192,7 @@ LOGGING = {
         },
     },
     'loggers': {
-        'test': {
+        logger_name: {
             'handlers': handler_list,
             'level': 'DEBUG',
             'propagate': False,

--- a/bushexa/config/settings.py
+++ b/bushexa/config/settings.py
@@ -155,3 +155,46 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]
 
+# Logger
+
+info_to_file = 'info_to_file'
+debug_to_file = 'debug_to_file'
+
+handler_list = [info_to_file]
+
+if DEBUG:
+    handler_list.append(debug_to_file)
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'basic': {
+            'format': '[{levelname}] [{asctime}] : {message}',
+            'style': '{',
+        },
+    },
+    'handlers': {
+        info_to_file: {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'utils/log.log'),
+            'formatter': 'basic',
+        },
+        debug_to_file: {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'utils/debug.log'),
+            'formatter': 'basic',
+        },
+    },
+    'loggers': {
+        'test': {
+            'handlers': handler_list,
+            'level': 'DEBUG',
+            'propagate': False,
+        }
+    }
+}
+


### PR DESCRIPTION
### Crawling 재작성

 - 이제 일정 시간동안 (timed task:9초 daily task:100초) 불러오지 못하면 request를 취소하며, 이 경우 기존 DB 내 정보가 유지됩니다.
 - 노선 경유역과 시간표 request를 async화했습니다.


### Logging 적용 ('bushexa' 로거)

두 가지 로거를 만들었습니다. logging 라이브러리를 import하고 logger = logging.getLogger("bushexa") 후 logger.debug()나 logger.info() 등 사용하시면 됩니다.
 
- 디버그용 로거 (.../utils/debug.log)

bushexa 로거에 의해 관리되는 DEBUG 레벨 이상의 로그가 기록됩니다. DEBUG = False인 경우 로깅되지 않습니다.

 - 일반용도 로거 (.../utils/log.log)

bushexa 로거에 의해 관리되는 INFO 레벨 이상의 로그가 기록됩니다. (DEBUG 로그는 표시되지 않음)


따라서 디버그 용도로 사용할 로그는 debug로, 항상 기록되어야 할 로그는 info로 로그를 남겨주시면 됩니다.